### PR TITLE
Start Wildfly in Debug mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM jboss/wildfly
 
-EXPOSE 8080 9990 9999
+EXPOSE 8080 9990 8787
 
 USER jboss
 RUN /opt/jboss/wildfly/bin/add-user.sh -u admin -p docker#admin --silent
-CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0"]
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "--debug", "8787", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0"]
 
 ADD hsqldb.jar /deploymenttmp/
 ADD executeInWildflyCli.sh /deploymenttmp/

--- a/executeInWildflyCli.sh
+++ b/executeInWildflyCli.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-      
+
 JBOSS_HOME=/opt/jboss/wildfly
 JBOSS_CLI=$JBOSS_HOME/bin/jboss-cli.sh
 JBOSS_MODE=${1:-"standalone"}


### PR DESCRIPTION
Added debug option to wildfly startup to allow debugging via eclipse.
Added gitattributes file to make sure that *.sh have correct line endings.
Otherwise docker build wont work.